### PR TITLE
change the MinkowskiEngine library path

### DIFF
--- a/models/resunet.py
+++ b/models/resunet.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
-import MinkowskiEngine as ME
-import MinkowskiEngine.MinkowskiOps as me
-from MinkowskiEngine import MinkowskiReLU
+import third_party.MinkowskiEngine as ME
+import third_party.MinkowskiEngine.MinkowskiEngine.MinkowskiOps as me
+from third_party.MinkowskiEngine import MinkowskiReLU
 
 from models.resnet import ResNetBase, get_norm
 from models.modules.common import ConvType, NormType, conv, conv_tr

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -20,7 +20,7 @@ from datasets.scannet200.scannet200_splits import (
 )
 
 import hydra
-import MinkowskiEngine as ME
+import third_party.MinkowskiEngine as ME
 import numpy as np
 import pytorch_lightning as pl
 import torch


### PR DESCRIPTION
I think the library path should be changed because Minkowski Engine was cloned into third_party folder in the following this change.

https://github.com/JonasSchult/Mask3D/commit/9f25bf357c97ed7b80402a6233eee8d940c64aeb