### PR TITLE
fix the SyntaxWarning in trainer.py

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1109,7 +1109,7 @@ class InstanceSegmentation(pl.LightningModule):
                                     )
                                 )
                             else:
-                                assert (False, "class not known!")
+                                assert False, "class not known!"
                     else:
                         ap_results[
                             f"{log_prefix}_{class_name}_val_ap"


### PR DESCRIPTION
The line assert(False, 'class not known!') is always true because the parentheses make Python interpret it as a tuple, which is always true when non-empty. I removed the parentheses to make it work.